### PR TITLE
feat(config): Retrieve configurations from database if not standalone

### DIFF
--- a/inc/bounce-current-ip.php
+++ b/inc/bounce-current-ip.php
@@ -3,6 +3,19 @@
 use CrowdSecBouncer\Constants;
 
 require_once __DIR__ . '/Bounce.php';
+require_once __DIR__.'/options-config.php';
+
+function getConfigs()
+{
+	$crowdSecWpPluginOptions = getCrowdSecOptionsConfig();
+	$finalConfigs = [];
+	foreach ($crowdSecWpPluginOptions as $option) {
+		$finalConfigs[$option['name']] = get_option($option['name']);
+	}
+
+	return $finalConfigs;
+}
+
 
 function safelyBounceCurrentIp()
 {
@@ -13,14 +26,8 @@ function safelyBounceCurrentIp()
     if (\PHP_SESSION_NONE === session_status()) {
         session_start();
     }
-    if (!file_exists(__DIR__.'/standalone-settings.php')) {
-        return;
-    }
-    require_once __DIR__.'/standalone-settings.php';
-    $crowdSecConfig = json_decode($crowdSecJsonStandaloneConfig, true);
-    if (!count($crowdSecConfig)) {
-        return;
-    }
+
+	$crowdSecConfig = getConfigs();
 	// Retro compatibility with crowdsec php lib < 0.14.0
     if($crowdSecConfig['crowdsec_bouncing_level'] === 'normal_boucing'){
 		$crowdSecConfig['crowdsec_bouncing_level'] = Constants::BOUNCING_LEVEL_NORMAL;


### PR DESCRIPTION
@see https://github.com/crowdsecurity/cs-wordpress-bouncer/issues/65

With this PR, we do not use the JSON settings file in "normal" mode anymore.